### PR TITLE
Fixed "NoMethodError"

### DIFF
--- a/recipes/mail.rb
+++ b/recipes/mail.rb
@@ -26,7 +26,7 @@
 
 unless node['express42']['handler']['mail_to'].empty?
   chef_gem 'pony' do
-    compile_time false
+    compile_time false if respond_to?(:compile_time)
   end
   Chef::Config.exception_handlers = [Express42::MailHandler.new(node['express42']['handler']['mail_from'], node['express42']['handler']['mail_to'])]
 end


### PR DESCRIPTION
Fixed "NoMethodError: undefined method `compile_time' for Chef::Resource::ChefGem" at executing vagrant up in express42-cookbooks/testo

Reference: http://jtimberman.housepub.org/blog/2015/03/20/chef-gem-compile-time-compatibility/
