### PR TITLE
Change in coloring

### DIFF
--- a/files/default/motd/express42_chef.py
+++ b/files/default/motd/express42_chef.py
@@ -75,10 +75,9 @@ class Express42_Chef(object):
         else:
             stime = int(time.time() - int(last_succesful_time))/60
             if stime <= int(chef_env['max_delay']):
-                status = bcolors.OKGREEN
+                status = str(stime) + " minute(s) ago"
             else:
-                status = bcolors.FAIL
-            status += str(stime) + " minute(s) ago" + bcolors.ENDC
+                status = bcolors.FAIL + str(stime) + " minute(s) ago" + bcolors.ENDC
         return status
 
     def check_last_run(self, last_succesful_time):
@@ -95,9 +94,9 @@ class Express42_Chef(object):
                 if ktime > datetime.fromtimestamp(float(last_succesful_time)):
                     status = bcolors.FAIL + 'unsuccessful' + bcolors.ENDC
                 else:
-                    status = bcolors.OKGREEN + 'successful' + bcolors.ENDC
+                    status = 'successful'
             else:
-                status = bcolors.OKGREEN + 'successful' + bcolors.ENDC
+                status = 'successful'
         else:
             status = bcolors.FAIL + "unknown" + bcolors.ENDC
 

--- a/files/default/motd/express42_chef.py
+++ b/files/default/motd/express42_chef.py
@@ -59,7 +59,7 @@ class Express42_Chef(object):
 
         return status
 
-    def get_last_succesful_run(self):
+    def get_last_successful_run(self):
         if not os.path.isfile('/var/chef/cache/last_successful_chef_run'):
             return None
         last_time = open('/var/chef/cache/last_successful_chef_run', 'r').read()
@@ -67,20 +67,20 @@ class Express42_Chef(object):
             return None
         return last_time
 
-    def check_last_succesful_run(self, last_succesful_time):
+    def check_last_successful_run(self, last_successful_time):
         with open("/etc/chef/env.json", "r") as json_file:
             chef_env = json.load(json_file)
-        if last_succesful_time is None:
+        if last_successful_time is None:
             status = bcolors.FAIL + "unknown" + bcolors.ENDC
         else:
-            stime = int(time.time() - int(last_succesful_time))/60
+            stime = int(time.time() - int(last_successful_time))/60
             if stime <= int(chef_env['max_delay']):
                 status = str(stime) + " minute(s) ago"
             else:
                 status = bcolors.FAIL + str(stime) + " minute(s) ago" + bcolors.ENDC
         return status
 
-    def check_last_run(self, last_succesful_time):
+    def check_last_run(self, last_successful_time):
         if os.path.isfile('/var/log/chef/client.log'):
             not_found = False
             for line in reversed(open("/var/log/chef/client.log").readlines()):
@@ -91,7 +91,7 @@ class Express42_Chef(object):
                 not_found = True
             if not not_found:
                 ktime = datetime.strptime(ltime.split('+')[0], '%Y-%m-%dT%H:%M:%S')
-                if ktime > datetime.fromtimestamp(float(last_succesful_time)):
+                if ktime > datetime.fromtimestamp(float(last_successful_time)):
                     status = bcolors.FAIL + 'unsuccessful' + bcolors.ENDC
                 else:
                     status = 'successful'
@@ -104,10 +104,10 @@ class Express42_Chef(object):
 
     def run(self):
 
-        last_time = self.get_last_succesful_run()
+        last_time = self.get_last_successful_run()
 
         self._sysinfo.add_header("Chef client status", self.check_running())
-        self._sysinfo.add_header("Last succesful chef run", self.check_last_succesful_run(last_time))
+        self._sysinfo.add_header("Last successful chef run", self.check_last_successful_run(last_time))
         self._sysinfo.add_header("Last chef run was", self.check_last_run(last_time))
 
         return succeed(None)

--- a/files/default/motd/express42_chefenv.py
+++ b/files/default/motd/express42_chefenv.py
@@ -37,8 +37,8 @@ class Express42_ChefEnv(object):
         else:
             env = str(chef_env['env'])
 
-        self._sysinfo.add_header("Node name", bcolors.OKGREEN + str(chef_env['node_name']) + bcolors.ENDC)
+        self._sysinfo.add_header("Node name", str(chef_env['node_name']))
         self._sysinfo.add_header("Environment", env)
-        self._sysinfo.add_header("Run list", bcolors.OKGREEN + str(chef_env['run_list']) + bcolors.ENDC)
+        self._sysinfo.add_header("Run list", str(chef_env['run_list']))
 
         return succeed(None)

--- a/files/default/motd/express42_load.py
+++ b/files/default/motd/express42_load.py
@@ -31,12 +31,10 @@ class Express42_Load(object):
     def run(self):
         cores = multiprocessing.cpu_count()
         loadavg = os.getloadavg()
-        loadavg_1 = bcolors.OKGREEN if loadavg[0] < cores else bcolors.FAIL
-        loadavg_1 += str(loadavg[0]) + bcolors.ENDC
-        loadavg_5 = bcolors.OKGREEN if loadavg[1] < cores else bcolors.FAIL
-        loadavg_5 += str(loadavg[1]) + bcolors.ENDC
-        loadavg_10 = bcolors.OKGREEN if loadavg[2] < cores else bcolors.FAIL
-        loadavg_10 += str(loadavg[2]) + bcolors.ENDC
+        loadavg_1 = str(loadavg[0]) if loadavg[0] < cores else bcolors.FAIL + str(loadavg[0]) + bcolors.ENDC
+        loadavg_5 = str(loadavg[1]) if loadavg[1] < cores else bcolors.FAIL + str(loadavg[1]) + bcolors.ENDC
+        loadavg_10 = str(loadavg[2]) if loadavg[2] < cores else bcolors.FAIL + str(loadavg[2]) + bcolors.ENDC
+
         self._sysinfo.add_header('Load Average',', '.join([loadavg_1, loadavg_5, loadavg_10]))
 
         return succeed(None)

--- a/files/default/motd/express42_memory.py
+++ b/files/default/motd/express42_memory.py
@@ -54,7 +54,7 @@ class Express42_Memory(object):
         msg = '{0:.2f}/{1:.2f} {2} ({3:.2f}%) '.format(memused, memtotal, units[i], mempcnt)
 
         if mempcnt < 85:
-            status = bcolors.OKGREEN + msg  + bcolors.ENDC
+            status = msg
         else:
             status = bcolors.FAIL + msg + bcolors.ENDC
 

--- a/files/default/motd/express42_memory.py
+++ b/files/default/motd/express42_memory.py
@@ -44,13 +44,14 @@ class Express42_Memory(object):
         meminfo = self.meminfo()
         memfree = float(meminfo['MemFree'].split(' ')[0])
         memtotal = float(meminfo['MemTotal'].split(' ')[0])
-        mempcnt = 100.0*memfree/memtotal
+        memused = float(memtotal-memfree)
+        mempcnt = 100.0*memused/memtotal
         i = 0
         while memtotal > 10000:
-            memfree /= 1024.0
+            memused /= 1024.0
             memtotal /= 1024.0
             i += 1
-        msg = '{0:.2f}/{1:.2f} {2} ({3:.2f}%) '.format(memfree, memtotal, units[i], mempcnt)
+        msg = '{0:.2f}/{1:.2f} {2} ({3:.2f}%) '.format(memused, memtotal, units[i], mempcnt)
 
         if mempcnt < 85:
             status = bcolors.OKGREEN + msg  + bcolors.ENDC


### PR DESCRIPTION
Coloring scheme
  Node name: always grey
  Environment: red and bold if node.default["express42"]["landscape"]["production"] == true else grey 
  Run list: always grey
  Chef client status: green if chef client is running else red
  Last succesful chef run: grey if chef successfully ran in last N\* minutes else red
  Last chef run was: grey if last chef run is successful else red
  Memory usage: grey if memory usage below 85% else red
  Load Average: grey if LA lesser than number of cores else red
  Usage of /: always grey but produces notes below if disk usage is above 85%

*N equals to chef client run interval plus splay

Good state coloring
![motd-good](https://cloud.githubusercontent.com/assets/12728509/14453125/81771f46-009b-11e6-8c7a-cea2c0280d05.png)

Bad state coloring
![motd-bad](https://cloud.githubusercontent.com/assets/12728509/14453124/8167c94c-009b-11e6-9b89-06a6c702c5e3.png)

MotD is not showed up if current load average is higher than number of cores.
![motd-verybad](https://cloud.githubusercontent.com/assets/12728509/14453123/814d4072-009b-11e6-96b1-7c18559338f1.png)

Still system information can be called manually by command 'landscape-sysinfo'
![motd-manual](https://cloud.githubusercontent.com/assets/12728509/14453264/7c235004-009c-11e6-8d5f-a6d4611f6cb1.png)
